### PR TITLE
Replace static libs with object libs to be included in final library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,20 +76,18 @@ set(LIBED25519_VERSION "${SOVERSION}-${EDIMPL}-${HASH}-${RANDOM}")
 
 add_library(ed25519 ${BUILD}
     src/ed25519.c
+    $<TARGET_OBJECTS:${EDIMPL}>
+    $<TARGET_OBJECTS:${HASH}>
+    $<TARGET_OBJECTS:${RANDOM}>
     )
 target_compile_definitions(ed25519 PUBLIC
     -DLIBED25519_VERSION=${LIBED25519_VERSION}
-    )
-target_link_libraries(ed25519
-    ${EDIMPL}
-    ${HASH}
-    ${RANDOM}
     )
 
 setup_ed25519_install_cmake(ed25519 ed25519Config)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(EXPORT ed25519Config DESTINATION share/ed25519/cmake)
-export(TARGETS ed25519 ${EDIMPL} ${HASH} ${RANDOM} FILE ed25519Config.cmake)
+export(TARGETS ed25519 FILE ed25519Config.cmake)
 target_include_directories(ed25519 PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/lib/ed25519/amd64-64-24k-pic/CMakeLists.txt
+++ b/lib/ed25519/amd64-64-24k-pic/CMakeLists.txt
@@ -4,11 +4,8 @@ set(LIB amd64-64-24k-pic)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 FILE(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 FILE(GLOB asm ${CMAKE_CURRENT_SOURCE_DIR}/*.s)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     ${sources}
     ${asm}
     )
 set_target_properties(${LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)
-

--- a/lib/ed25519/amd64-64-24k/CMakeLists.txt
+++ b/lib/ed25519/amd64-64-24k/CMakeLists.txt
@@ -4,10 +4,8 @@ set(LIB amd64-64-24k)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 FILE(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 FILE(GLOB asm ${CMAKE_CURRENT_SOURCE_DIR}/*.s)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     ${sources}
     ${asm}
     )
 set_target_properties(${LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/lib/ed25519/ref10/CMakeLists.txt
+++ b/lib/ed25519/ref10/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(LIB ref10)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 FILE(GLOB sources ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     ${sources}
     )
 set_target_properties(${LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/lib/hash/sha2_openssl/CMakeLists.txt
+++ b/lib/hash/sha2_openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenSSL REQUIRED)
 
 set(LIB sha2_openssl)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     sha256.c
     sha512.c
     )
@@ -13,5 +13,3 @@ target_include_directories(${LIB} PUBLIC
     )
 
 set_target_properties(${LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/lib/hash/sha3_brainhub/CMakeLists.txt
+++ b/lib/hash/sha3_brainhub/CMakeLists.txt
@@ -1,10 +1,7 @@
 set(LIB sha3_brainhub)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     sha3.c
     sha3_256.c
     sha3_512.c
     )
 set_target_properties(${LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)
-

--- a/lib/randombytes/openssl/CMakeLists.txt
+++ b/lib/randombytes/openssl/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenSSL REQUIRED)
 
 set(LIB rand_openssl)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     randombytes.c
     )
 target_link_libraries(${LIB}
@@ -10,5 +10,3 @@ target_link_libraries(${LIB}
 target_include_directories(${LIB} PUBLIC
     ${OPENSSL_INCLUDE_DIR}
     )
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/lib/randombytes/random/CMakeLists.txt
+++ b/lib/randombytes/random/CMakeLists.txt
@@ -1,6 +1,4 @@
 set(LIB dev_random)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     random.c
     )
-
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/lib/randombytes/urandom/CMakeLists.txt
+++ b/lib/randombytes/urandom/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(LIB dev_urandom)
-add_library(${LIB}
+add_library(${LIB} OBJECT
     urandom.c
     )
-setup_ed25519_install_cmake(${LIB} ed25519Config)

--- a/test/ed25519/CMakeLists.txt
+++ b/test/ed25519/CMakeLists.txt
@@ -3,11 +3,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_subdirectory(tosha3)
 
 macro(edtest edname hash rand)
-  addtest(test-${edname} ed25519_test.cpp)
-  target_link_libraries(test-${edname}
-      ${edname}
-      ${hash}
-      ${rand}
+  addtest(test-${edname}
+      ed25519_test.cpp
+      $<TARGET_OBJECTS:${edname}>
+      $<TARGET_OBJECTS:${hash}>
+      $<TARGET_OBJECTS:${rand}>
       )
 
   gethash(${hash} RESULT)

--- a/test/ed25519/tosha3/CMakeLists.txt
+++ b/test/ed25519/tosha3/CMakeLists.txt
@@ -1,14 +1,14 @@
 
 
-add_executable(tosha3 tosha3.cpp)
+add_executable(tosha3
+    tosha3.cpp
+    $<TARGET_OBJECTS:ref10>
+    $<TARGET_OBJECTS:sha3_brainhub>
+    $<TARGET_OBJECTS:dev_urandom>
+    )
 target_compile_definitions(tosha3 PUBLIC
     -DTESTDATAIN_PATH=${CMAKE_SOURCE_DIR}/test/ed25519/sign.input.with.sha2.txt
     -DTESTDATAOUT_PATH=${CMAKE_SOURCE_DIR}/test/ed25519/sign.input.with.sha3.txt
-    )
-target_link_libraries(tosha3
-    ref10
-    sha3_brainhub
-    dev_urandom
     )
 set_target_properties(tosha3 PROPERTIES EXCLUDE_FROM_ALL TRUE)
 

--- a/test/hash/CMakeLists.txt
+++ b/test/hash/CMakeLists.txt
@@ -1,5 +1,5 @@
 macro(shatest name)
-  addtest(test-${name} sha_test.cpp)
+  addtest(test-${name} sha_test.cpp $<TARGET_OBJECTS:${name}>)
 
   gethash(${name} RESULT)
   if(${RESULT} STREQUAL "SHA2")
@@ -13,7 +13,6 @@ macro(shatest name)
   target_compile_definitions(test-${name} PUBLIC
       -DTESTDATA_PATH=${testdata}
       )
-  target_link_libraries(test-${name} ${name})
 endmacro()
 
 

--- a/test/randombytes/CMakeLists.txt
+++ b/test/randombytes/CMakeLists.txt
@@ -1,6 +1,5 @@
 macro(rngtest name)
-  addtest(test-${name} random.cpp)
-  target_link_libraries(test-${name} ${name})
+  addtest(test-${name} random.cpp $<TARGET_OBJECTS:${name}>)
 endmacro()
 
 rngtest(${RANDOM})


### PR DESCRIPTION
ed, hash, and random implementations were compiled and installed as separate static libraries, which required manual linking to each of them.

Fixes introduced allow to use a single `ed25519` library, which contains all required symbols.